### PR TITLE
add clustersysteminfo delay

### DIFF
--- a/chart/templates/job-clustersysteminfo.yaml
+++ b/chart/templates/job-clustersysteminfo.yaml
@@ -30,6 +30,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
     spec:
+      initContainers:
+        - name: delay
+          image: "alpine:latest"
+          command: ["/bin/sleep","{{ default 0 .Values.clustersysteminfo.delay }}"]
       containers:
         - name: clustersysteminfo-check
           image: "{{ .Values.clustersysteminfo.images.clustersysteminfo.repository }}:{{ .Values.clustersysteminfo.images.clustersysteminfo.tag }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -66,6 +66,7 @@ kafka:
 # clustersysteminfo check
 clustersysteminfo:
   enabled: false
+  delay: 0 # number of seconds to delay clustersysteminfo execution
 
   fullnameOverride: clustersysteminfo
 


### PR DESCRIPTION
This change allows to set a delay before the clustersysteminfo script is being executed. This may be needed e.g. to wait for AWS Route53 to propagate new records to [their DNS servers](https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetChange.html).