### PR TITLE
Issues with rrty(s)

### DIFF
--- a/docker-compose/traefik/openwifi_letsencrypt.yaml
+++ b/docker-compose/traefik/openwifi_letsencrypt.yaml
@@ -39,7 +39,7 @@ http:
     owgw-rttys-view:
       loadBalancer:
         servers:
-          - url: "http://owgw.wlan.local:5913/"
+          - url: "https://owgw.wlan.local:5913/"
     owrrm-openapi:
       loadBalancer:
         servers:
@@ -144,6 +144,6 @@ tcp:
     owgw-rttys:
       entryPoints: "owgwrttys"
       service: "owgw-rttys"
-      rule: "HostSNI(`{{ env "SDKHOSTNAME" }}`)"
+      rule: "HostSNI(`*`)"
       tls:
-        certResolver: openwifi
+        passthrough: true


### PR DESCRIPTION
When we click on "Connect" in the dashboard, the rtty server (ucentral gw) is sending the connect request to the rtty client (AP) successfully. AP also is responding and connecting to the gw. But there are a couple of issues.

Issue # 1
Immediately after clicking on Connect, the browser takes us to a rtty server (again ucentral gw only.. but on differnt port) url for example, https://owgw.shastacloud.com:5913/connect/fca974d05e9f6b437fc091be914ef8d5, but that page says "Bad Gateway" error. So the server is missing something. Hence we cannot see the AP's connect status on the dashboard as the above page is throwing "Bad gateway" error.

Issue # 2
The rtty daemon on the client (AP) keeps timing out and keeps reconnecting.

Couple of changes to fix these.

The first change is to make the rttys dashboard url https. It will resolve the SSL exception / Bad gw error ie issue #1 in the bug description.

The second change is to set the communication between rtty on AP and rttys on GW as passthrough. The GW pushes non-tls config to the AP  hence AP tries to connect with non-tls, but the rtty server is configured with TLS. We need to make it passthrough until the rttys server supports TLS.