### PR TITLE
https://telecominfraproject.atlassian.net/browse/WIFI-13246

### DIFF
--- a/chart/environment-values/values.openwifi-qa.single-external-db.yaml
+++ b/chart/environment-values/values.openwifi-qa.single-external-db.yaml
@@ -66,7 +66,7 @@ postgresql-ha:
     postgresPassword: postgres
     repmgrPassword: repmgr
     maxConnections: 1000
-    sharedBuffers: 50MB
+    sharedBuffers: 128MB
     resources:
       requests:
         cpu: 250m


### PR DESCRIPTION
From resouces. Shared_buffer should be 25% os system memory

Signed-off-by: stephb9959 <stephane.bourque@gmail.com>