### PR TITLE
WIFI-13821 - Load balancer started acting up: change annotations

### DIFF
--- a/cgw/values/cgw.yaml
+++ b/cgw/values/cgw.yaml
@@ -15,10 +15,10 @@ services:
   cgw:
     type: LoadBalancer
     annotations:
-      #service.beta.kubernetes.io/aws-load-balancer-type: nlb-ip
       service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: ssl
-      service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "15003"
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: metrics
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: /health
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: http
       service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true
       service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "16002"
-      alb.ingress.kubernetes.io/healthcheck-path: /health


### PR DESCRIPTION
Load balancer started acting up: change annotations
It started failing health checks out of the blue. So be specific as to health check port name and protocol.
Possibly the health check path annotation previously used was no longer honoured so switch to newer annotation name for it.